### PR TITLE
Add simple language menu to site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY html/ /usr/share/nginx/html/
 COPY i18n/ /usr/share/nginx/i18n/
 
 RUN for f in `ls /usr/share/nginx/i18n/*.yml`; do \
-        /usr/share/nginx/i18n/translate.pl $f /usr/share/nginx/html/index.html \
+        /usr/share/nginx/i18n/translate.pl /usr/share/nginx/i18n/en.yml $f /usr/share/nginx/html/index.html \
       > /usr/share/nginx/html/index.`basename -s .yml $f`.html ; \
     done \
     && rm /usr/share/nginx/html/index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
 FROM nginx
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y libyaml-perl
+
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY i18n/ /usr/share/nginx/i18n/
 COPY html/ /usr/share/nginx/html/
+
+RUN for f in `ls /usr/share/nginx/i18n/*.yml`; do \
+        /usr/share/nginx/i18n/translate.pl $f /usr/share/nginx/html/index.html \
+      > /usr/share/nginx/html/index.`basename -s .yml $f`.html ; \
+    done \
+    && rm /usr/share/nginx/html/index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y libyaml-perl
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY i18n/ /usr/share/nginx/i18n/
 COPY html/ /usr/share/nginx/html/
+COPY i18n/ /usr/share/nginx/i18n/
 
 RUN for f in `ls /usr/share/nginx/i18n/*.yml`; do \
         /usr/share/nginx/i18n/translate.pl $f /usr/share/nginx/html/index.html \

--- a/html/assets/css/lang.css
+++ b/html/assets/css/lang.css
@@ -1,0 +1,82 @@
+/*
+ * Styles specific to the language menu 
+ */
+
+.lang {
+    position: absolute;
+    right: 5px;
+    top: 8px;
+    border-left: 2px solid transparent;
+    border-right: 2px solid transparent;
+    border-top: 2px solid transparent;
+}
+
+.lang, .lang li, .lang ul {
+    display: block;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+}
+
+.lang, .lang li, .lang ul {
+    display: block;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+}
+
+.lang li a, .lang li a:link, .lang li a:visited, .lang li a:active {
+    text-decoration: none;
+    display: inline-block;
+    padding: 4px 8px;
+}
+
+.lang li ul {
+    display: none;
+    right: -2px;
+    margin-top: -2px;
+    position: absolute;
+    background-color: #fff;
+    padding: 20px;
+    border: 2px solid #e4e4e4;
+    white-space: nowrap;
+    z-index: 2;
+}
+
+.lang li ul li {
+    display: inline-block;
+    vertical-align: top;
+    text-align: left;
+    width: 170px;
+}
+
+.lang li ul li ul {
+    position: relative;
+    margin: -4px 0;
+    padding: 0;
+    border: 0;
+    top: 0;
+}
+
+.lang li ul li ul li {
+    display: block;
+}
+
+.lang:hover {
+    border-left: 2px solid #e4e4e4;
+    border-right: 2px solid #e4e4e4;
+    border-top: 2px solid #e4e4e4;
+    background-color: #fff;
+}
+
+.lang:hover li ul {
+    display: block;
+}
+
+.lang > li > a {
+    z-index:3;
+    background-color: white;
+    position: relative;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{title}}</title>
-<meta name="description" content="">
+<meta name="description" content="{{description}}">
 <link rel="canonical" href="https://thebitcoincash.fund" />
 <link href="https://fonts.googleapis.com/css?family=Montserrat:400,800" rel="stylesheet">
 <link href="assets/css/merged.css" rel="stylesheet" type="text/css" media="all" />

--- a/html/index.html
+++ b/html/index.html
@@ -8,6 +8,7 @@
 <link rel="canonical" href="https://thebitcoincash.fund" />
 <link href="https://fonts.googleapis.com/css?family=Montserrat:400,800" rel="stylesheet">
 <link href="assets/css/merged.css" rel="stylesheet" type="text/css" media="all" />
+<link href="assets/css/lang.css" rel="stylesheet" type="text/css" media="all" />
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="{{locale}}" />
@@ -37,6 +38,22 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
+	<ul class="lang">
+	  <li><a>{{language}}</a>
+	    <ul>
+	      <li>
+		<ul>
+		  <li><a href="/en/">English</a></li>
+		  <li><a href="/es/">Español</a></li>
+		  <li><a href="/nl/">Nederlands</a></li>
+		  <li><a href="/pt_PT/">Português Portugal</a></li>
+		  <li><a href="/ja/">日本語</a></li>
+		  <li><a href="/zh/">中文</a></li>
+		</ul>
+	      </li>
+	    </ul>
+	  </li>
+	</ul>
         <picture>
           <!-- Desktop -->
           <source media="(min-width: 768px)"

--- a/html/index.html
+++ b/html/index.html
@@ -3,21 +3,22 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>The Bitcoin Cash Fund</title>
-<meta name="description" content="A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash.">
+<title>{{title}}</title>
+<meta name="description" content="">
 <link rel="canonical" href="https://thebitcoincash.fund" />
 <link href="https://fonts.googleapis.com/css?family=Montserrat:400,800" rel="stylesheet">
 <link href="assets/css/merged.css" rel="stylesheet" type="text/css" media="all" />
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 <meta property="og:type" content="website" />
+<meta property="og:locale" content="{{locale}}" />
 <meta property="og:url" content="https://thebitcoincash.fund" />
-<meta property="og:site_name" content="The Bitcoin Cash Fund" />
-<meta property="og:title" content="The Bitcoin Cash Fund" />
-<meta property="og:description" content="A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash." />
+<meta property="og:site_name" content="{{title}}" />
+<meta property="og:title" content="{{title}}" />
+<meta property="og:description" content="{{description}}" />
 <meta property="og:image" content="https://thebitcoincash.fund/assets/img/bcf_opengraph.jpg" />
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="The Bitcoin Cash Fund" />
-<meta name="twitter:description" content="A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash." />
+<meta name="twitter:title" content="{{title}}" />
+<meta name="twitter:description" content="{{description}}" />
 <meta name="twitter:image" content="https://thebitcoincash.fund/assets/img/bcf_opengraph.jpg" />
 <meta name="twitter:site" content="@BitcoinCashFund">
 <meta name="twitter:creator" content="@BitcoinCashFund">
@@ -47,8 +48,8 @@
           <source srcset="assets/img/hero_tablet.png" />
           <img src="assets/img/hero_desktop.png" class="img-responsive" style="width:100%;" />
         </picture>
-        <h1 id="hero-title">The Bitcoin Cash Fund</h1>
-        <p id="hero-lead">A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash.</p>
+        <h1 id="hero-title">{{title}}</h1>
+        <p id="hero-lead">{{description}}</p>
       </div>
     </div>
   </div>
@@ -57,7 +58,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <p>The <strong>Bitcoin Cash Fund</strong> is a non-profit organisation, with the mission of distributing donated funds to projects that promote Bitcoin Cash.</p>
+        <p>{{subhead}}</p>
       </div>
     </div>
   </div>
@@ -66,22 +67,22 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <h2>What Is Bitcoin Cash?</h2>
+        <h2>{{what_is_bch_title}}</h2>
         <span class="border"></span>
       </div>
     </div>
     <div class="row">
       <div class="col-md-4 what-bch-answer">
         <img src="assets/svg/globe.svg" class="bch-business-icon">
-        <p>A person-to-person online global digital cash system.</p>
+        <p>{{what_is_bch_answer1}}</p>
       </div>
       <div class="col-md-4 what-bch-answer">
         <img src="assets/svg/cubes.svg" class="bch-business-icon">
-        <p>A decentralized currency not controlled by any one person.</p>
+        <p>{{what_is_bch_answer2}}</p>
       </div>
       <div class="col-md-4 what-bch-answer">
         <img src="assets/svg/flash.svg" class="bch-business-icon">
-        <p>A secure, high-speed and low-cost payment system.</p>
+        <p>{{what_is_bch_answer3}}</p>
       </div>
     </div>
   </div>
@@ -100,11 +101,10 @@
         </picture>
       </div>
       <div class="col-md-7">
-        <h2>Our Mission</h2>
+        <h2>{{mission_title}}</h2>
         <span class="border"></span>
-        <p id="mission-lead">Our mission is to help Bitcoin Cash serve one billion users within five years.</p>
-        <p>Anyone, or any team, can put in a proposal to request funding from the BCF. The proposals will be assessed based on cost versus impact and S.M.A.R.T principles, to make sure funds are allocated where they will have maximum impact.</p>
-        <p>Members of the community are encouraged to take ownership of their projects and see them through to completion.</p>
+        <p id="mission-lead">{{mission_lead}}</p>
+        {{mission_text}}
       </div>
     </div>
   </div>
@@ -113,9 +113,9 @@
   <div id="donate-wrapper" class="container">
     <div class="row">
       <div class="col-md-8">
-        <h2>Donate</h2>
+        <h2>{{donate_title}}</h2>
         <span class="border-white"></span>
-        <p class="donate-text">This is the official Bitcoin Cash Fund funding address. Simply copy and paste, or scan the address into your favourite wallet to donate. All donations are welcome.</p>
+        <p class="donate-text">{{donate_text}}</p>
       </div>
       <div class="col-md-4">
         <img src="assets/img/qr_code.png" id="donate-qr-code" class="img-responsive">
@@ -130,15 +130,15 @@
 </div>
 <div id="team">
   <div class="container">
-    <h2>Meet the Team</h2>
+    <h2>{{team_title}}</h2>
     <span class="border"></span>
     <div class="row">
       <div class="col-sm-4 col-md-4">
         <div class="team-wrapper">
           <img src="assets/img/team_ian_descoteaux.jpg" class="img-responsive team-photo">
           <p class="team-name">Ian Descôteaux</p>
-          <p class="team-role">Board Member</p>
-          <p class="team-bio">Entered the Bitcoin space in 2010 and built up a mining farm and has been mining ever since.</p>
+          <p class="team-role">{{team_role_board_member}}</p>
+          <p class="team-bio">{{team_ian_descoteaux_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/checksum0" target="_blank">@checksum0</a>
           </p>
@@ -148,8 +148,8 @@
         <div class="team-wrapper">
           <img src="assets/img/team_paul_wasensteiner.jpg" class="img-responsive team-photo">
           <p class="team-name">Paul Wasensteiner</p>
-          <p class="team-role">Executive Director</p>
-          <p class="team-bio">Entered the Bitcoin space in 2011, and founded the Bitcoin Cash Fund in November 2017.</p>
+          <p class="team-role">{{team_role_executive_director}}</p>
+          <p class="team-bio">{{team_paul_wasensteiner_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/__pcd__" target="_blank">@__pcd__</a>
           </p>
@@ -159,8 +159,8 @@
         <div class="team-wrapper">
           <img src="assets/img/team_haipo_yang.jpg" class="img-responsive team-photo">
           <p class="team-name">Haipo Yang</p>
-          <p class="team-role">Board Member</p>
-          <p class="team-bio">Founded the highly successful mining pool ViaBTC, and led the R&amp;D team at ZeusMiner. </p>
+          <p class="team-role">{{team_role_board_member}}</p>
+          <p class="team-bio">{{team_haipo_yang_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/yhaiyang" target="_blank">@yhaiyang</a>
           </p>
@@ -172,13 +172,13 @@
 </div>
 <div id="advisors">
   <div class="container">
-    <h2>Our Advisors</h2>
+    <h2>{{advisors_title}}</h2>
     <span class="border"></span>
     <div class="row">
       <div class="col-sm-6 col-lg-3">
         <div class="team-wrapper"> <img src="assets/img/team_jack_liu.jpg" class="img-responsive team-photo">
           <p class="team-name">Jack C. Liu</p>
-          <p class="team-bio">Formerly served as Chief Strategy Officer of OKCoin Group, and co-founded OKEx and OKLink.</p>
+          <p class="team-bio">{{advisors_jack_liu_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/liujackc" target="_blank">@liujackc</a>
           </p>
@@ -187,7 +187,7 @@
       <div class="col-sm-6 col-lg-3">
         <div class="team-wrapper"><img src="assets/img/team_roger_ver.jpg" class="img-responsive team-photo">
           <p class="team-name">Roger Ver</p>
-          <p class="team-bio">World's first Investor in Bitcoin startups and has been investing in Bitcoin startups since early 2011.</p>
+          <p class="team-bio">{{advisors_roger_ver_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/rogerkver" target="_blank">@rogerkver</a>
           </p>
@@ -197,7 +197,7 @@
       <div class="col-sm-6 col-lg-3">
         <div class="team-wrapper"><img src="assets/img/team_peter_rizun.jpg" class="img-responsive team-photo">
           <p class="team-name">Dr. Peter R. Rizun</p>
-          <p class="team-bio">Chief Scientist for Bitcoin Unlimited, committed to researching the bottlenecks to Bitcoin scaling.</p>
+          <p class="team-bio">{{advisors_peter_rizun_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/peterrizun" target="_blank">@peterrizun</a>
           </p>
@@ -206,9 +206,7 @@
       <div class="col-sm-6 col-lg-3">
         <div class="team-wrapper"><img src="assets/img/team_mike_komaransky.jpg" class="img-responsive team-photo">
           <p class="team-name">Mike Komaransky</p>
-          <p class="team-bio">
-          
-          An investor and advocate of Bitcoin since 2010, Mike was a partner at DRW, and was Head of Trading at Cumberland Mining from 2014 until June 2017.</p>
+          <p class="team-bio">{{advisors_mike_komaransky_bio}}</p>
           <p class="team-social">
             <a href="https://twitter.com/mkomaransky" target="_blank">@mkomaransky</a>
           </p>
@@ -221,13 +219,13 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <h2>Stay Informed</h2>
+        <h2>{{stay_informed_title}}</h2>
         <span class="border"></span>
         <form action="https://facebook.us17.list-manage.com/subscribe/post" method="POST" class="form-inline">
           <input type="hidden" name="u" value="d150e27fa1a1ce16c5c3e1d1e">
           <input type="hidden" name="id" value="8d0e1cb511">
-          <input type="email" class="form-control input-lg" autocapitalize="off" autocorrect="off" name="MERGE0" id="MERGE0" size="25" value="" placeholder="name@example.com">
-          <input type="submit" id="subscribe-btn" class="btn btn-default btn-lg" name="submit" value="Subscribe">
+          <input type="email" class="form-control input-lg" autocapitalize="off" autocorrect="off" name="MERGE0" id="MERGE0" size="25" value="" placeholder="{{stay_informed_email_placeholder}}">
+          <input type="submit" id="subscribe-btn" class="btn btn-default btn-lg" name="submit" value="{{stay_informed_subscribe_button}}">
         </form>
       </div>
     </div>
@@ -237,9 +235,9 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <h2>Sponsors</h2>
+        <h2>{{sponsors_title}}</h2>
         <span class="border"></span>
-        <p>These corporate sponsors are fully aligned with our goals and are pushing Bitcoin Cash adoption forward at a lightning pace.</p>
+        <p>{{sponsors_text}}</p>
       </div>
     </div>
     <div class="row">
@@ -254,7 +252,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-        <h2>Get In Touch</h2>
+        <h2>{{get_in_touch_title}}</h2>
         <span class="border-white"></span>
         <ul id="contact-sns-list">		
          <li><a href="https://chat.thebitcoincash.fund" target="_blank"><img src="assets/svg/sns-chat.svg" alt="Chat" class="contact-sns-img-chat"></a></li>
@@ -269,10 +267,10 @@
         </ul>
         <div id="contact-form">
           <form action="https://formcarry.com/s/r1pJYQNgM" method="POST">
-            <input class="form-control input-lg contact-input" type="text" placeholder="Name" name="name">
-            <input class="form-control input-lg contact-input" type="email" placeholder="Email" name="email">
-            <textarea class="form-control input-lg contact-input" rows="7" placeholder="Message" name="message"></textarea>
-            <input id="contact-btn" class="btn btn-lg" type="submit" value="Send">
+            <input class="form-control input-lg contact-input" type="text" placeholder="{{get_in_touch_name_placeholder}}" name="name">
+            <input class="form-control input-lg contact-input" type="email" placeholder="{{get_in_touch_email_placeholder}}" name="email">
+            <textarea class="form-control input-lg contact-input" rows="7" placeholder="{{get_in_touch_message_placeholder}}" name="message"></textarea>
+            <input id="contact-btn" class="btn btn-lg" type="submit" value="{{get_in_touch_send_button}}">
           </form>
         </div>
       </div>
@@ -284,14 +282,19 @@
     <div class="row">
       <div class="col-xs-12">
         <div id="footer-content">
-          <h2>More to Come</h2>
+          <h2>{{more_to_come_title}}</h2>
           <span class="border"></span>
-          <p>This fund has done tremendous work in the short time it has been around. But there is still much more to come. Be sure to watch this space!</p>
-          <h3 id="footer-links-heading">Learn More</h3>
-          <p><a href="https://www.yours.org/content/bitcoin-cash-fund---weekly-report-22-12-17-119c8c84e3b1/" target="_blank">The Bitcoin Cash Fund Weekly Report - 22.12.2017</a></p>
-		  <p><a href="https://www.yours.org/content/bitcoin-cash-fund---weekly-report-15-12-17-21d352a71424/" target="_blank">The Bitcoin Cash Fund Weekly report - 15.12.2017</a></p> 
-		  <p><a href="https://www.yours.org/content/announcing-the-bitcoin-cash-fund---update-1-38f985d0add1/" target="_blank">Press Release: Announcing the Bitcoin Cash Fund - Update 1</a><br>(<a href="https://www.yours.org/content/bch---bcf-----1-f77c64360217" target="_blank">中文</a> | <a href="https://www.yours.org/content/anunciando-o-fundo-bitcoin-cash---actualiza--o-1-f260e4db792c" target="_blank">Português</a> | <a href="https://www.yours.org/content/presentamos-el-fondo-de-bitcoin-cash-750e5935be25" target="_blank">Español</a>)</p>
-          <p><a href="https://github.com/The-Bitcoin-Cash-Fund/Docs/blob/master/BCF-Funding-Proposal-Request-Template.md" target="_blank">Participate in the Fund and propose a project for funding</a></p>
+          <p>{{more_to_come_text}}</p>
+          <h3 id="footer-links-heading">{{more_to_come_learn}}</h3>
+          <p><a href="{{more_to_come_3_url}}" target="_blank">{{more_to_come_3_title}}</a></p>
+          <p><a href="{{more_to_come_2_url}}" target="_blank">{{more_to_come_2_title}}</a></p>
+          <p><a href="{{more_to_come_1_url}}" target="_blank">{{more_to_come_1_title}}</a><br>
+	    (<a href="https://www.yours.org/content/announcing-the-bitcoin-cash-fund---update-1-38f985d0add1/" target="_blank">English</a>
+	    | <a href="https://www.yours.org/content/bch---bcf-----1-f77c64360217" target="_blank">中文</a>
+	    | <a href="https://www.yours.org/content/anunciando-o-fundo-bitcoin-cash---actualiza--o-1-f260e4db792c" target="_blank">Português</a>
+	    | <a href="https://www.yours.org/content/presentamos-el-fondo-de-bitcoin-cash-750e5935be25" target="_blank">Español</a>)
+	  </p>
+          <p><a href="https://github.com/The-Bitcoin-Cash-Fund/Docs/blob/master/BCF-Funding-Proposal-Request-Template.md" target="_blank">{{more_to_come_participate}}</a></p>
           <span class="border footer-img-link-border"></span>
           <a href="https://bitcoincash.org/" target="_blank" class="footer-img-link">
             <img alt="Bitcoin Cash Project" src="assets/img/more_bch.jpg">
@@ -312,7 +315,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12">
-      <p>Copyright &copy; 2017-2018 Bitcoin Cash Fund</p>
+      <p>{{copyright_text}}</p>
       </div>
     </div>
   </div>

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -1,5 +1,6 @@
 en:
   locale: en_GB
+  language: English
   title: The Bitcoin Cash Fund
   description: A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash.
   subhead: The <strong>Bitcoin Cash Fund</strong> is a non-profit organisation, with the mission of distributing donated funds to projects that promote Bitcoin Cash.

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -1,0 +1,57 @@
+en:
+  locale: en_GB
+  title: The Bitcoin Cash Fund
+  description: A community-driven, grassroots project to accelerate the adoption of Bitcoin Cash.
+  subhead: The <strong>Bitcoin Cash Fund</strong> is a non-profit organisation, with the mission of distributing donated funds to projects that promote Bitcoin Cash.
+  what_is_bch_title: What Is Bitcoin Bash?
+  what_is_bch_answer1: A person-to-person online global digital cash system.
+  what_is_bch_answer2: A decentralized currency not controlled by any one person.
+  what_is_bch_answer3: A secure, high-speed and low-cost payment system.
+  mission_title: Our Mission
+  mission_lead: Our mission is to help Bitcoin Cash serve one billion users within five years.
+  mission_text: >
+    <p>Anyone, or any team, can put in a proposal to request funding from the BCF. The proposals will be assessed based on cost versus impact and S.M.A.R.T principles, to make sure funds are allocated where they will have maximum impact.</p>
+    <p>Members of the community are encouraged to take ownership of their projects and see them through to completion.</p>
+  donate_title: Donate
+  donate_text: This is the official Bitcoin Cash Fund funding address. Simply copy and paste, or scan the address into your favourite wallet to donate. All donations are welcome.
+  team_title: Meet the Team
+  team_role_board_member: Board Member
+  team_role_executive_director: Executive Director
+  team_ian_descoteaux_bio: >
+    Entered the Bitcoin space in 2010 and built up a mining farm and has been mining ever since.
+  team_paul_wasensteiner_bio: >
+    Entered the Bitcoin space in 2011, and founded the Bitcoin Cash Fund in November 2017.
+  team_haipo_yang_bio: >
+    Founded the highly successful mining pool ViaBTC, and led the R&amp;D team at ZeusMiner.
+  advisors_title: Our Advisors
+  advisors_jack_liu_bio: >
+    Formerly served as Chief Strategy Officer of OKCoin Group, and co-founded OKEx and OKLink.
+  advisors_roger_ver_bio: >
+    World's first Investor in Bitcoin startups and has been investing in Bitcoin startups since early 2011.
+  advisors_peter_rizun_bio: >
+    Chief Scientist for Bitcoin Unlimited, committed to researching the bottlenecks to Bitcoin scaling.
+  advisors_mike_komaransky_bio: >
+    An investor and advocate of Bitcoin since 2010, Mike was a partner at DRW, and was Head of Trading at Cumberland Mining from 2014 until June 2017.
+  stay_informed_title: Stay Informed
+  stay_informed_email_placeholder: name@example.com
+  stay_informed_subscribe_button: Subscribe
+  sponsors_title: Sponsors
+  sponsors_text: >
+    These corporate sponsors are fully aligned with our goals and are pushing Bitcoin Cash adoption forward at a lightning pace.
+  get_in_touch_title: Get In Touch
+  get_in_touch_name_placeholder: Name
+  get_in_touch_email_placeholder: Email
+  get_in_touch_message_placeholder: Message
+  get_in_touch_send_button: Send
+  more_to_come_title: More to Come
+  more_to_come_text: >
+    This fund has done tremendous work in the short time it has been around. But there is still much more to come. Be sure to watch this space!
+  more_to_come_learn: Learn More
+  more_to_come_participate: Participate in the Fund and propose a project for funding
+  copyright_text: Copyright &copy; 2017-2018 Bitcoin Cash Fund
+  more_to_come_1_title: "Press Release: Announcing the Bitcoin Cash Fund - Update 1"
+  more_to_come_1_url: https://www.yours.org/content/announcing-the-bitcoin-cash-fund---update-1-38f985d0add1/
+  more_to_come_2_title: The Bitcoin Cash Fund Weekly report - 15.12.2017
+  more_to_come_2_url: https://www.yours.org/content/bitcoin-cash-fund---weekly-report-15-12-17-21d352a71424/
+  more_to_come_3_title: The Bitcoin Cash Fund Weekly report - 22.12.2017
+  more_to_come_3_url: https://www.yours.org/content/bitcoin-cash-fund---weekly-report-22-12-17-119c8c84e3b1/

--- a/i18n/translate.pl
+++ b/i18n/translate.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use YAML qw'LoadFile';
+use open qw(:std :utf8);
 
 binmode(STDOUT, ":utf8");
 

--- a/i18n/translate.pl
+++ b/i18n/translate.pl
@@ -5,14 +5,20 @@ use open qw(:std :utf8);
 
 binmode(STDOUT, ":utf8");
 
-my $ymlfile = shift or die "YML file not specified";
-my $yml = LoadFile($ymlfile);
-my $lang = (keys %{$yml})[0];
-my $translation = $yml->{$lang};
+my $basefile = shift or die "YML file not specified";
+my $baseyml = LoadFile($basefile);
+my $baselang = (keys %{$baseyml})[0];
+my $base = $baseyml->{$baselang};
+
+my $langfile = shift or die "YML file not specified";
+my $langyml = LoadFile($langfile);
+my $lang = (keys %{$langyml})[0];
+my $translation = $langyml->{$lang};
 
 while (<>) {
-  for my $key (keys %{$translation}) {
-    s/\{\{$key\}\}/$translation->{$key}/g;
-  }
-  print;
+    for my $key (keys %{$base}) {
+	my $text = $translation->{$key} || $base->{$key};
+	s/\{\{$key\}\}/$text/g;
+    }
+    print;
 }

--- a/i18n/translate.pl
+++ b/i18n/translate.pl
@@ -2,6 +2,8 @@
 
 use YAML qw'LoadFile';
 
+binmode(STDOUT, ":utf8");
+
 my $ymlfile = shift or die "YML file not specified";
 my $yml = LoadFile($ymlfile);
 my $lang = (keys %{$yml})[0];

--- a/i18n/translate.pl
+++ b/i18n/translate.pl
@@ -1,0 +1,15 @@
+#!/usr/bin/perl
+
+use YAML qw'LoadFile';
+
+my $ymlfile = shift or die "YML file not specified";
+my $yml = LoadFile($ymlfile);
+my $lang = (keys %{$yml})[0];
+my $translation = $yml->{$lang};
+
+while (<>) {
+  for my $key (keys %{$translation}) {
+    s/\{\{$key\}\}/$translation->{$key}/g;
+  }
+  print;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,11 @@
+## Basic lang detection
+map $http_accept_language $lang {
+    default en;
+#    ~*es es;
+#    ~*pt pt;
+#    ~*zh zh;
+}
+
 server {
     listen       80;
     server_name  thebitcoincash.fund;
@@ -12,8 +20,11 @@ server {
     
     root   /usr/share/nginx/html;
 
+    rewrite ^/(en|es|pt|zh)/?$ /index.$1.html last;
+    rewrite ^/(en|es|pt|zh)(/.+)$ $2 last;
+
     location / {
-        index  index.html;
+        index  index.$lang.html;
     }
 
     location ~*  \.(jpg|jpeg|png|gif|ico)$ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,8 +22,8 @@ server {
     
     root   /usr/share/nginx/html;
 
-    rewrite ^/(en|es|pt|zh)/?$ /index.$1.html last;
-    rewrite ^/(en|es|pt|zh)(/.+)$ $2 last;
+    rewrite ^/(en|es|ja|nl|pt-PT|zh)/?$ /index.$1.html last;
+    rewrite ^/(en|es|ja|nl|pt-PT|zh)(/.+)$ $2 last;
 
     location / {
         index  index.$lang.html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,9 @@
 map $http_accept_language $lang {
     default en;
 #    ~*es es;
-#    ~*pt pt;
+#    ~*ja ja;
+#    ~*nl nl;
+#    ~*pt pt-PT;
 #    ~*zh zh;
 }
 


### PR DESCRIPTION
Adds a simple language menu to the top right corner of the site. The screenshot bellow shows it's appearance. All languages currently proposed as PR are added. Adding and removing a language can be done easily by adding and removing a line from `index.html`. Obviously, each entry in that menu must match an existing yaml file.

This menu was introduced on top of #13.

![langmenushot1](https://user-images.githubusercontent.com/253588/34969381-80c7e0aa-fa66-11e7-879a-3f18dbf50dbf.png)
